### PR TITLE
chore(dependabot): update config to produce semantic commit messages

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -6,6 +6,9 @@ update_configs:
       update_schedule: 'daily'
       version_requirement_updates: 'increase_versions'
       target_branch: 'next'
+      commit_message:
+          prefix: 'chore'
+          include_scope: true
       automerged_updates:
           - match:
                 dependency_name: '@dhis2/*'


### PR DESCRIPTION
This should fix the issue we are currently experiencing with the dependabot not producing semantic commit messages.